### PR TITLE
Add duecredit MWE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,6 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# duecredit
+.duecredit.p

--- a/mars/__init__.py
+++ b/mars/__init__.py
@@ -5,6 +5,7 @@ Mars is a demo project for showing neat ideas.
 
 # Add imports here
 from .mars import *
+from .due import *
 
 # Handle versioneer
 from ._version import get_versions

--- a/mars/due.py
+++ b/mars/due.py
@@ -1,0 +1,74 @@
+# emacs: at the end of the file
+# ex: set sts=4 ts=4 sw=4 et:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### #
+"""
+
+Stub file for a guaranteed safe import of duecredit constructs:  if duecredit
+is not available.
+
+To use it, place it into your project codebase to be imported, e.g. copy as
+
+    cp stub.py /path/tomodule/module/due.py
+
+Note that it might be better to avoid naming it duecredit.py to avoid shadowing
+installed duecredit.
+
+Then use in your code as
+
+    from .due import due, Doi, BibTeX, Text
+
+See  https://github.com/duecredit/duecredit/blob/master/README.md for examples.
+
+Origin:     Originally a part of the duecredit
+Copyright:  2015-2019  DueCredit developers
+License:    BSD-2
+"""
+
+__version__ = '0.0.8'
+
+
+class InactiveDueCreditCollector(object):
+    """Just a stub at the Collector which would not do anything"""
+    def _donothing(self, *args, **kwargs):
+        """Perform no good and no bad"""
+        pass
+
+    def dcite(self, *args, **kwargs):
+        """If I could cite I would"""
+        def nondecorating_decorator(func):
+            return func
+        return nondecorating_decorator
+
+    active = False
+    activate = add = cite = dump = load = _donothing
+
+    def __repr__(self):
+        return self.__class__.__name__ + '()'
+
+
+def _donothing_func(*args, **kwargs):
+    """Perform no good and no bad"""
+    pass
+
+
+try:
+    from duecredit import due, BibTeX, Doi, Url, Text
+    if 'due' in locals() and not hasattr(due, 'cite'):
+        raise RuntimeError(
+            "Imported due lacks .cite. DueCredit is now disabled")
+except Exception as e:
+    if not isinstance(e, ImportError):
+        import logging
+        logging.getLogger("duecredit").error(
+            "Failed to import duecredit due to %s" % str(e))
+    # Initiate due stub
+    due = InactiveDueCreditCollector()
+    BibTeX = Doi = Url = Text = _donothing_func
+
+# Emacs mode definitions
+# Local Variables:
+# mode: python
+# py-indent-offset: 4
+# tab-width: 4
+# indent-tabs-mode: nil
+# End:

--- a/mars/mars.py
+++ b/mars/mars.py
@@ -4,6 +4,7 @@ Mars is a demo project for showing neat ideas.
 
 Handles the primary functions
 """
+from .due import due, Doi, BibTeX
 
 
 def canvas(with_attribution=True):
@@ -29,6 +30,11 @@ def canvas(with_attribution=True):
     return quote
 
 
+@due.dcite(Doi("10.1021/acs.jpcb.8b11527"), description="Solves all problems")
+def cite_matt_test():
+    pass
+
+
 if __name__ == "__main__":
     # Do something if this file is invoked on its own
-    print(canvas())
+    cite_matt_test()

--- a/scratch/xyz.py
+++ b/scratch/xyz.py
@@ -1,0 +1,4 @@
+from mars import cite_matt_test
+
+
+cite_matt_test()


### PR DESCRIPTION
Just seeind what https://github.com/duecredit/duecredit looks like in practice; I can decorate a function with a DOI and make it (a little) easier to cite. Pretty much all I did was follow the README and add the DOI of one of my papers

```
(openff-dev) [mars] python -m duecredit scratch/xyz.py                                                             duecredit  ✭

DueCredit Report:
  - Solves all problems / mars.mars:cite_matt_test (v 0.0.0+4.g5edec42.dirty) [1]

0 packages cited
0 modules cited
1 function cited

References
----------

[1] Thompson, M.W. et al., 2019. Scalable Screening of Soft Matter: A Case Study of Mixtures of Ionic Liquids and Organic Solvents. The Journal of Physical Chemistry B, 123(6), pp.1340–1347.